### PR TITLE
Support Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email="wannaphong@yahoo.com",
     packages=find_packages(exclude=["tests", "tests.*"]),
     url="https://github.com/PyThaiNLP/padthai",
-    python_requires=">=3.7",
+    python_requires=">=3.6",
     include_package_data=True,
     install_requires=requirements,
     license="Apache Software License 2.0",


### PR DESCRIPTION
Can you support Python3.6 ? 

I tested on my machine (Python 3.6) that working fine.

![Screenshot at 2021-08-05 12-08-01](https://user-images.githubusercontent.com/144775/128294331-afb45aca-f496-48ce-a084-bb23f704beeb.png)
